### PR TITLE
Handle UTC timestamps

### DIFF
--- a/CSVIngest.cpp
+++ b/CSVIngest.cpp
@@ -2,6 +2,7 @@
 #include "Pig.h"
 #include "PigPosture.h"
 #include "Application.h"
+#include "TimeUtils.h"
 
 #include <iostream>
 #include <fstream>
@@ -110,7 +111,8 @@ void parse_and_batch_insert(const std::string& filepath,
             }
         }
 
-        auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+        tm.tm_isdst = 0; // timestamps are provided in UTC
+        auto tp = std::chrono::system_clock::from_time_t(timegm_utc(&tm));
 
         for (size_t i = 0; i < pig_ids.size(); ++i) {
             std::string score_str;

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A robust CSV parser designed to process and store pig posture data in MongoDB. T
 
 - Parse CSV files with tab-separated values
 - Support for timestamps in format `YYYY_MM_DD_HH_MM_SS`
+- Timestamps are interpreted as UTC for accurate storage (converted using `timegm`/`_mkgmtime`)
 - Automatic pig registration in the database
 - Batch processing for efficient database operations
 - Error handling and reporting
@@ -41,8 +42,10 @@ A robust CSV parser designed to process and store pig posture data in MongoDB. T
    - Be tab-separated
    - Have a header row with column names
    - First column should be timestamps in format `YYYY_MM_DD_HH_MM_SS`
+   - Timestamps are expected to be in **UTC**
    - Other columns should be named `ID_X` where X is the pig ID number
    - Values should be numeric scores
+   - The parser stores timestamps in MongoDB using UTC semantics
 
 2. Run the application using the provided script:
    ```bash
@@ -72,7 +75,7 @@ Timestamp	ID_129	ID_131	ID_143	...
 ```
 
 Where:
-- The first column contains timestamps in the format `YYYY_MM_DD_HH_MM_SS`
+- The first column contains timestamps in the format `YYYY_MM_DD_HH_MM_SS` (UTC)
 - Each subsequent column represents a pig with ID in the header (e.g., `ID_129`)
 - Values are numeric scores (typically 0-9)
 - Fields are separated by tabs (`\t`)
@@ -93,6 +96,7 @@ The application uses two MongoDB collections:
 ## Troubleshooting
 
 - **Timestamp parsing errors**: Ensure your timestamps are in the format `YYYY_MM_DD_HH_MM_SS`
+- **Wrong time zone**: The parser assumes timestamps are UTC. Convert local times to UTC before ingestion
 - **Database connection issues**: Check that MongoDB is running and accessible
 - **CSV parsing errors**: Verify that your CSV files use tabs as separators and follow the expected format
 

--- a/TimeUtils.h
+++ b/TimeUtils.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <ctime>
+
+inline std::time_t timegm_utc(std::tm* tm) {
+#ifdef _WIN32
+    return _mkgmtime(tm);
+#else
+    return timegm(tm);
+#endif
+}

--- a/test_csv_parser.cpp
+++ b/test_csv_parser.cpp
@@ -7,6 +7,7 @@
 #include <ctime>
 #include <iomanip>
 #include <unordered_set>
+#include "TimeUtils.h"
 
 int main() {
     std::string filepath = "build/cold_folder/unknown1.csv";
@@ -62,7 +63,8 @@ int main() {
                 tm.tm_min = std::stoi(timestamp_str.substr(14, 2));         // Minute (0-59)
                 tm.tm_sec = std::stoi(timestamp_str.substr(17, 2));         // Second (0-59)
                 
-                auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+                tm.tm_isdst = 0;
+                auto tp = std::chrono::system_clock::from_time_t(timegm_utc(&tm));
                 successful_timestamps++;
                 
                 // Print the first few successful timestamps
@@ -101,7 +103,8 @@ int main() {
                 std::cerr << "❌ Timestamp parse fail: " << timestamp_str << std::endl;
                 failed_timestamps++;
             } else {
-                auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+                tm.tm_isdst = 0;
+                auto tp = std::chrono::system_clock::from_time_t(timegm_utc(&tm));
                 successful_timestamps++;
                 
                 // Print the first few successful timestamps

--- a/test_parser.cpp
+++ b/test_parser.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <chrono>
 #include <ctime>
+#include "TimeUtils.h"
 
 int main() {
     std::string filepath = "cold_folder/unknown1.csv";
@@ -59,7 +60,8 @@ int main() {
                 tm.tm_min = std::stoi(timestamp_str.substr(14, 2));         // Minute (0-59)
                 tm.tm_sec = std::stoi(timestamp_str.substr(17, 2));         // Second (0-59)
                 
-                auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+                tm.tm_isdst = 0;
+                auto tp = std::chrono::system_clock::from_time_t(timegm_utc(&tm));
                 successful_timestamps++;
                 
                 // Print the first few successful timestamps
@@ -79,7 +81,8 @@ int main() {
                 std::cerr << "❌ Timestamp parse fail: " << timestamp_str << std::endl;
                 failed_timestamps++;
             } else {
-                auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+                tm.tm_isdst = 0;
+                auto tp = std::chrono::system_clock::from_time_t(timegm_utc(&tm));
                 successful_timestamps++;
                 
                 // Print the first few successful timestamps


### PR DESCRIPTION
## Summary
- ensure timestamps are treated as UTC when converting to `time_point`
- provide cross-platform `timegm_utc` helper
- update tests to use UTC conversion
- document UTC expectations in README

## Testing
- `./run.sh` *(fails: libmongocxx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558d5846308324b36edb5fa14bc083