### PR TITLE
Handle decimal posture scores

### DIFF
--- a/CSVIngest.cpp
+++ b/CSVIngest.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <sstream>
 #include <iomanip>
+#include <cmath>
 #include <unordered_set>
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/json.hpp>
@@ -119,7 +120,9 @@ void parse_and_batch_insert(const std::string& filepath,
             if (score_str.empty() || pig_ids[i] == -1) continue;
 
             try {
-                int score = std::stoi(score_str);
+                // Allow scores like "4" or "4.5" by parsing as float first
+                float score_f = std::stof(score_str);
+                int score = static_cast<int>(std::round(score_f));
                 int pig_id = pig_ids[i];
 
                 if (checked_pigs.find(pig_id) == checked_pigs.end()) {

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A robust CSV parser designed to process and store pig posture data in MongoDB. T
    - Have a header row with column names
    - First column should be timestamps in format `YYYY_MM_DD_HH_MM_SS`
    - Other columns should be named `ID_X` where X is the pig ID number
-   - Values should be numeric scores
+   - Values should be numeric scores (decimals are allowed and will be rounded)
 
 2. Run the application using the provided script:
    ```bash
@@ -74,7 +74,7 @@ Timestamp	ID_129	ID_131	ID_143	...
 Where:
 - The first column contains timestamps in the format `YYYY_MM_DD_HH_MM_SS`
 - Each subsequent column represents a pig with ID in the header (e.g., `ID_129`)
-- Values are numeric scores (typically 0-9)
+- Values are numeric scores (decimals will be rounded to the nearest integer)
 - Fields are separated by tabs (`\t`)
 
 ## Database Structure

--- a/test_csv_parser.cpp
+++ b/test_csv_parser.cpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <ctime>
 #include <iomanip>
+#include <cmath>
 #include <unordered_set>
 
 int main() {
@@ -78,7 +79,9 @@ int main() {
                     if (score_str.empty() || pig_ids[i] == -1) continue;
                     
                     try {
-                        int score = std::stoi(score_str);
+                        // Accept floating point values and round to nearest int
+                        float score_f = std::stof(score_str);
+                        int score = static_cast<int>(std::round(score_f));
                         
                         // Just for demonstration, print a few scores
                         if (successful_timestamps <= 3 && i < 3) {


### PR DESCRIPTION
## Summary
- allow parsing decimal values for posture scores by using `std::stof`
- round float values when converting to integer
- update test tool and documentation accordingly

## Testing
- `./run.sh` *(fails: libmongocxx missing)*

------
https://chatgpt.com/codex/tasks/task_e_68558d52cb1c8324975e940e5e98a5ed