### PR TITLE
Handle invalid header columns

### DIFF
--- a/CSVIngest.cpp
+++ b/CSVIngest.cpp
@@ -64,6 +64,9 @@ void parse_and_batch_insert(const std::string& filepath,
                 std::cerr << "⚠️ Failed to parse pig ID from header: " << cell << std::endl;
                 pig_ids.push_back(-1); // placeholder for tracking bad header
             }
+        } else {
+            std::cerr << "⚠️ Unexpected header column: " << cell << " - skipping" << std::endl;
+            pig_ids.push_back(-1); // maintain alignment for data rows
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A robust CSV parser designed to process and store pig posture data in MongoDB. T
    - Have a header row with column names
    - First column should be timestamps in format `YYYY_MM_DD_HH_MM_SS`
    - Other columns should be named `ID_X` where X is the pig ID number
+   - Columns not following this pattern will be skipped with a warning
    - Values should be numeric scores
 
 2. Run the application using the provided script:


### PR DESCRIPTION
## Summary
- warn if header columns do not follow `ID_x` pattern
- document that unexpected columns are skipped

## Testing
- `./run.sh` *(fails: libmongocxx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558d36c4b8832480fccff98ff03f8a