### PR TITLE
Handle reappearing files in watcher

### DIFF
--- a/Application.cpp
+++ b/Application.cpp
@@ -9,7 +9,7 @@
 #include <sstream>
 #include <algorithm>
 #include <cctype>
-#include <unordered_set>
+#include <unordered_map>
 
 namespace fs = std::filesystem;
 
@@ -335,15 +335,27 @@ void Application::configureSettings() {
 void Application::startFileWatcher() {
     // Create a lambda function to watch the directory
     auto watchFunction = [this]() {
-        std::unordered_set<std::string> seen;
+        // Track processed files and their last modification times
+        std::unordered_map<std::string, std::filesystem::file_time_type> seen;
 
         while (this->running) {
             try {
+                // Remove records for files that no longer exist
+                for (auto it = seen.begin(); it != seen.end(); ) {
+                    if (!fs::exists(it->first)) {
+                        it = seen.erase(it);
+                    } else {
+                        ++it;
+                    }
+                }
+
                 for (const auto& entry : fs::directory_iterator(this->config.watchFolder)) {
                     if (entry.path().extension() == ".csv") {
                         std::string filepath = entry.path().string();
-                        if (seen.find(filepath) == seen.end()) {
-                            seen.insert(filepath);
+                        auto modTime = fs::last_write_time(entry);
+                        auto it = seen.find(filepath);
+                        if (it == seen.end() || it->second != modTime) {
+                            seen[filepath] = modTime;
                             this->processFile(filepath);
                         }
                     }

--- a/FileWatcher.cpp
+++ b/FileWatcher.cpp
@@ -1,7 +1,7 @@
 #include "FileWatcher.h"
 #include "CSVIngest.h"
 #include <filesystem>
-#include <unordered_set>
+#include <unordered_map>
 #include <chrono>
 #include <thread>
 #include <iostream>
@@ -17,17 +17,28 @@ void watch_directory(const std::string& dir_path, ThreadPool& pool,
                      mongocxx::collection pigs_collection,
                      mongocxx::collection posture_collection) {
     namespace fs = std::filesystem;
-    std::unordered_set<std::string> seen;
+    std::unordered_map<std::string, fs::file_time_type> seen;
 
     std::cout << "⚠️ Warning: Using legacy file watching method.\n";
     std::cout << "   Consider using the new Application class for enhanced features.\n\n";
 
     while (true) {
+        // Clean out records for files that have been removed
+        for (auto it = seen.begin(); it != seen.end();) {
+            if (!fs::exists(it->first)) {
+                it = seen.erase(it);
+            } else {
+                ++it;
+            }
+        }
+
         for (const auto& entry : fs::directory_iterator(dir_path)) {
             if (entry.path().extension() == ".csv") {
                 std::string filepath = entry.path().string();
-                if (seen.find(filepath) == seen.end()) {
-                    seen.insert(filepath);
+                auto modTime = fs::last_write_time(entry);
+                auto it = seen.find(filepath);
+                if (it == seen.end() || it->second != modTime) {
+                    seen[filepath] = modTime;
                     pool.enqueue([filepath, pigs_collection, posture_collection]() {
                         // Using default values for stats and batchSize
                         parse_and_batch_insert(filepath, pigs_collection, posture_collection, nullptr, 1000);


### PR DESCRIPTION
## Summary
- track modification times for watched files
- clean up removed entries from watch set

## Testing
- `cmake ..` *(fails: libmongocxx missing)*

------
https://chatgpt.com/codex/tasks/task_e_68558d3016c08324998fb6f2b534e542