### PR TITLE
Avoid mongocxx collection copies

### DIFF
--- a/CSVIngest.cpp
+++ b/CSVIngest.cpp
@@ -14,12 +14,12 @@
 using bsoncxx::builder::stream::document;
 using bsoncxx::builder::stream::finalize;
 
-bool pig_exists(int pig_id, mongocxx::collection& pigs_collection) {
+bool pig_exists(int pig_id, const mongocxx::collection& pigs_collection) {
     auto result = pigs_collection.find_one(document{} << "pigId" << pig_id << finalize);
     return result ? true : false;
 }
 
-void insert_pig_if_needed(int pig_id, mongocxx::collection& pigs_collection) {
+void insert_pig_if_needed(int pig_id, const mongocxx::collection& pigs_collection) {
     if (!pig_exists(pig_id, pigs_collection)) {
         Pig new_pig(
             pig_id,
@@ -35,8 +35,8 @@ void insert_pig_if_needed(int pig_id, mongocxx::collection& pigs_collection) {
 }
 
 void parse_and_batch_insert(const std::string& filepath,
-    mongocxx::collection pigs_collection,
-    mongocxx::collection posture_collection,
+    const mongocxx::collection& pigs_collection,
+    const mongocxx::collection& posture_collection,
     ProcessingStats* stats,
     int batchSize) {
 

--- a/CSVIngest.h
+++ b/CSVIngest.h
@@ -14,8 +14,8 @@ using ProgressCallback = std::function<void(int, int)>;
 
 void parse_and_batch_insert(
     const std::string& filepath,
-    mongocxx::collection pigs_collection,
-    mongocxx::collection posture_collection,
+    const mongocxx::collection& pigs_collection,
+    const mongocxx::collection& posture_collection,
     ProcessingStats* stats = nullptr,
     int batchSize = 1000);
 

--- a/FileWatcher.cpp
+++ b/FileWatcher.cpp
@@ -14,8 +14,8 @@
 // This function is kept for backward compatibility
 // The Application class now handles file watching with more features
 void watch_directory(const std::string& dir_path, ThreadPool& pool,
-                     mongocxx::collection pigs_collection,
-                     mongocxx::collection posture_collection) {
+                     const mongocxx::collection& pigs_collection,
+                     const mongocxx::collection& posture_collection) {
     namespace fs = std::filesystem;
     std::unordered_set<std::string> seen;
 
@@ -28,7 +28,7 @@ void watch_directory(const std::string& dir_path, ThreadPool& pool,
                 std::string filepath = entry.path().string();
                 if (seen.find(filepath) == seen.end()) {
                     seen.insert(filepath);
-                    pool.enqueue([filepath, pigs_collection, posture_collection]() {
+                    pool.enqueue([filepath, &pigs_collection, &posture_collection]() {
                         // Using default values for stats and batchSize
                         parse_and_batch_insert(filepath, pigs_collection, posture_collection, nullptr, 1000);
                     });

--- a/FileWatcher.h
+++ b/FileWatcher.h
@@ -7,6 +7,6 @@
 // Function declaration
 void watch_directory(const std::string& directory_path,
                      ThreadPool& pool,
-                     mongocxx::collection pigs_collection,
-                     mongocxx::collection posture_collection);
+                     const mongocxx::collection& pigs_collection,
+                     const mongocxx::collection& posture_collection);
 


### PR DESCRIPTION
## Summary
- pass `mongocxx::collection` objects by const reference
- capture MongoDB collections by reference in `watch_directory`

## Testing
- `cmake ..` *(fails: libmongocxx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558d19b6c88324a2881f4f66160735