### PR TITLE
Improve timestamp parsing

### DIFF
--- a/CSVIngest.cpp
+++ b/CSVIngest.cpp
@@ -11,6 +11,8 @@
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/json.hpp>
 
+constexpr std::size_t TIMESTAMP_LENGTH = 19;
+
 using bsoncxx::builder::stream::document;
 using bsoncxx::builder::stream::finalize;
 
@@ -83,31 +85,17 @@ void parse_and_batch_insert(const std::string& filepath,
 
         std::tm tm = {};
 
-        // Parse timestamp in format YYYY_MM_DD_HH_MM_SS (e.g., 2022_08_22_02_20_00)
-        if (timestamp_str.length() == 19 &&
-            timestamp_str[4] == '_' && timestamp_str[7] == '_' && timestamp_str[10] == '_' &&
-            timestamp_str[13] == '_' && timestamp_str[16] == '_') {
-
-            try {
-                tm.tm_year = std::stoi(timestamp_str.substr(0, 4)) - 1900; // Year since 1900
-                tm.tm_mon = std::stoi(timestamp_str.substr(5, 2)) - 1;     // Month (0-11)
-                tm.tm_mday = std::stoi(timestamp_str.substr(8, 2));         // Day (1-31)
-                tm.tm_hour = std::stoi(timestamp_str.substr(11, 2));        // Hour (0-23)
-                tm.tm_min = std::stoi(timestamp_str.substr(14, 2));         // Minute (0-59)
-                tm.tm_sec = std::stoi(timestamp_str.substr(17, 2));         // Second (0-59)
-            } catch (const std::exception& e) {
-                std::cerr << "❌ Timestamp parse fail: " << timestamp_str << " - " << e.what() << std::endl;
-                continue;
-            }
+        // Parse timestamp using explicit format definitions
+        std::istringstream ts_stream(timestamp_str);
+        if (timestamp_str.length() == TIMESTAMP_LENGTH) {
+            ts_stream >> std::get_time(&tm, "%Y_%m_%d_%H_%M_%S");
         } else {
-            // Try standard format as fallback
-            std::istringstream ts_stream(timestamp_str);
             ts_stream >> std::get_time(&tm, "%Y-%m-%d %H:%M:%S");
-
-            if (ts_stream.fail()) {
-                std::cerr << "❌ Timestamp parse fail: " << timestamp_str << std::endl;
-                continue;
-            }
+        }
+        if (ts_stream.fail()) {
+            std::cerr << "❌ Timestamp parse fail: " << timestamp_str << std::endl;
+            if (stats) stats->errorCount++;
+            continue;
         }
 
         auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));

--- a/CSVIngest.h
+++ b/CSVIngest.h
@@ -12,6 +12,8 @@ struct ProcessingStats;
 // Callback function type for progress updates
 using ProgressCallback = std::function<void(int, int)>;
 
+constexpr std::size_t TIMESTAMP_LENGTH = 19;
+
 void parse_and_batch_insert(
     const std::string& filepath,
     mongocxx::collection pigs_collection,

--- a/test_csv_parser.cpp
+++ b/test_csv_parser.cpp
@@ -38,6 +38,8 @@ int main() {
         }
     }
 
+    constexpr std::size_t TIMESTAMP_LENGTH = 19;
+
     int successful_timestamps = 0;
     int failed_timestamps = 0;
     
@@ -49,21 +51,16 @@ int main() {
 
         std::tm tm = {};
         
-        // Parse timestamp in format YYYY_MM_DD_HH_MM_SS (e.g., 2022_08_22_02_20_00)
-        if (timestamp_str.length() == 19 && 
-            timestamp_str[4] == '_' && timestamp_str[7] == '_' && timestamp_str[10] == '_' &&
-            timestamp_str[13] == '_' && timestamp_str[16] == '_') {
-            
-            try {
-                tm.tm_year = std::stoi(timestamp_str.substr(0, 4)) - 1900; // Year since 1900
-                tm.tm_mon = std::stoi(timestamp_str.substr(5, 2)) - 1;     // Month (0-11)
-                tm.tm_mday = std::stoi(timestamp_str.substr(8, 2));         // Day (1-31)
-                tm.tm_hour = std::stoi(timestamp_str.substr(11, 2));        // Hour (0-23)
-                tm.tm_min = std::stoi(timestamp_str.substr(14, 2));         // Minute (0-59)
-                tm.tm_sec = std::stoi(timestamp_str.substr(17, 2));         // Second (0-59)
-                
-                auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
-                successful_timestamps++;
+        // Parse timestamp using explicit format definitions
+        std::istringstream ts_stream(timestamp_str);
+        if (timestamp_str.length() == TIMESTAMP_LENGTH) {
+            ts_stream >> std::get_time(&tm, "%Y_%m_%d_%H_%M_%S");
+        } else {
+            ts_stream >> std::get_time(&tm, "%Y-%m-%d %H:%M:%S");
+        }
+        if (!ts_stream.fail()) {
+            auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+            successful_timestamps++;
                 
                 // Print the first few successful timestamps
                 if (successful_timestamps <= 5) {
@@ -88,27 +85,9 @@ int main() {
                         std::cerr << "❌ Parse error at pig index " << i << ": " << e.what() << std::endl;
                     }
                 }
-            } catch (const std::exception& e) {
-                std::cerr << "❌ Timestamp parse fail: " << timestamp_str << " - " << e.what() << std::endl;
-                failed_timestamps++;
-            }
         } else {
-            // Try standard format as fallback
-            std::istringstream ts_stream(timestamp_str);
-            ts_stream >> std::get_time(&tm, "%Y-%m-%d %H:%M:%S");
-            
-            if (ts_stream.fail()) {
-                std::cerr << "❌ Timestamp parse fail: " << timestamp_str << std::endl;
-                failed_timestamps++;
-            } else {
-                auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
-                successful_timestamps++;
-                
-                // Print the first few successful timestamps
-                if (successful_timestamps <= 5) {
-                    std::cout << "✅ Successfully parsed timestamp: " << timestamp_str << std::endl;
-                }
-            }
+            std::cerr << "❌ Timestamp parse fail: " << timestamp_str << std::endl;
+            failed_timestamps++;
         }
     }
 

--- a/test_parser.cpp
+++ b/test_parser.cpp
@@ -35,6 +35,8 @@ int main() {
         }
     }
 
+    constexpr std::size_t TIMESTAMP_LENGTH = 19;
+
     int successful_timestamps = 0;
     int failed_timestamps = 0;
     
@@ -46,47 +48,24 @@ int main() {
 
         std::tm tm = {};
         
-        // Parse timestamp in format YYYY_MM_DD_HH_MM_SS (e.g., 2022_08_22_02_20_00)
-        if (timestamp_str.length() == 19 && 
-            timestamp_str[4] == '_' && timestamp_str[7] == '_' && timestamp_str[10] == '_' &&
-            timestamp_str[13] == '_' && timestamp_str[16] == '_') {
-            
-            try {
-                tm.tm_year = std::stoi(timestamp_str.substr(0, 4)) - 1900; // Year since 1900
-                tm.tm_mon = std::stoi(timestamp_str.substr(5, 2)) - 1;     // Month (0-11)
-                tm.tm_mday = std::stoi(timestamp_str.substr(8, 2));         // Day (1-31)
-                tm.tm_hour = std::stoi(timestamp_str.substr(11, 2));        // Hour (0-23)
-                tm.tm_min = std::stoi(timestamp_str.substr(14, 2));         // Minute (0-59)
-                tm.tm_sec = std::stoi(timestamp_str.substr(17, 2));         // Second (0-59)
-                
-                auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
-                successful_timestamps++;
-                
-                // Print the first few successful timestamps
-                if (successful_timestamps <= 5) {
-                    std::cout << "✅ Successfully parsed timestamp: " << timestamp_str << std::endl;
-                }
-            } catch (const std::exception& e) {
-                std::cerr << "❌ Timestamp parse fail: " << timestamp_str << " - " << e.what() << std::endl;
-                failed_timestamps++;
-            }
+        // Parse timestamp using explicit format definitions
+        std::istringstream ts_stream(timestamp_str);
+        if (timestamp_str.length() == TIMESTAMP_LENGTH) {
+            ts_stream >> std::get_time(&tm, "%Y_%m_%d_%H_%M_%S");
         } else {
-            // Try standard format as fallback
-            std::istringstream ts_stream(timestamp_str);
             ts_stream >> std::get_time(&tm, "%Y-%m-%d %H:%M:%S");
-            
-            if (ts_stream.fail()) {
-                std::cerr << "❌ Timestamp parse fail: " << timestamp_str << std::endl;
-                failed_timestamps++;
-            } else {
-                auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
-                successful_timestamps++;
+        }
+        if (!ts_stream.fail()) {
+            auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+            successful_timestamps++;
                 
                 // Print the first few successful timestamps
                 if (successful_timestamps <= 5) {
                     std::cout << "✅ Successfully parsed timestamp: " << timestamp_str << std::endl;
                 }
-            }
+        } else {
+            std::cerr << "❌ Timestamp parse fail: " << timestamp_str << std::endl;
+            failed_timestamps++;
         }
     }
 


### PR DESCRIPTION
## Summary
- centralize timestamp length in `TIMESTAMP_LENGTH`
- parse timestamps using `std::get_time`
- update csv parser tests

## Testing
- `./run.sh` *(fails: missing libmongocxx)*

------
https://chatgpt.com/codex/tasks/task_e_68558d10f19c8324a8921ac11d2f2122